### PR TITLE
Replaced GHA `set-output` with `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
           if_false: latest
       - name: Determine image tag
         id: imagetag
-        run: echo "::set-output name=value::${TAG_OR_BRANCH##*/}"
+        run: echo "value=${TAG_OR_BRANCH##*/}" >> $GITHUB_OUTPUT
         env:
           TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
       - name: Build

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -51,7 +51,7 @@ jobs:
           HELM_PACKAGE_PATH="${HELM_PACKAGE_OUTPUT##"Successfully packaged chart and saved it to: "}"
 
           echo "HELM_PACKAGE_PATH=${HELM_PACKAGE_PATH}"
-          echo ::set-output name=helm_package_path::${HELM_PACKAGE_PATH}
+          echo "helm_package_path=${HELM_PACKAGE_PATH}" >> $GITHUB_OUTPUT
 
       - name: Set Git refname
         id: set-git-refname
@@ -59,7 +59,7 @@ jobs:
           GIT_REFNAME="$(echo "${{ github.ref }}" | sed -r 's@refs/(heads|pull|tags)/@@g')"
 
           echo "GIT_REFNAME=${GIT_REFNAME}"
-          echo ::set-output name=git_refname::${GIT_REFNAME}
+          echo "git_refname=${GIT_REFNAME}" >> $GITHUB_OUTPUT
 
       - name: Set Helm push enabled
         id: set-helm-push-enabled
@@ -72,7 +72,7 @@ jobs:
           fi
 
           echo "HELM_PUSH_ENABLED=${HELM_PUSH_ENABLED}"
-          echo ::set-output name=helm_push_enabled::${HELM_PUSH_ENABLED}
+          echo "helm_push_enabled=${HELM_PUSH_ENABLED}" >> $GITHUB_OUTPUT
 
       - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
         name: Check Helm chart version in repository


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Replaced `::set-output` with `>> $GITHUB_OUTPUT`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Deprecated, will be removed in 2023-05-31.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Details: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

Tested [in another PR](https://github.com/banzaicloud/koperator/pull/906/files#diff-dce4cd1ca1dc3e5849de0fd3f3c7b132ad537e4ba79ba191f5de4330484b214bR39), worked well.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- ~Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)~
- ~Logging code meets the guideline~
- ~User guide and development docs updated (if needed)~
