### PR TITLE
Use current timestamp even with non-randomized samples

### DIFF
--- a/formats/syslog/syslog.go
+++ b/formats/syslog/syslog.go
@@ -63,7 +63,7 @@ func SampleData() TemplateData {
 	return TemplateData{
 		Facility: 20,
 		severity: 5,
-		dateTime: time.Date(2011, 6, 25, 20, 0, 4, 0, time.UTC),
+		dateTime: dateTime: time.Now().UTC(),
 		Host:     viper.GetString("message.host"),
 		AppName:  viper.GetString("message.appname"),
 		PID:      1143,

--- a/formats/syslog/syslog.go
+++ b/formats/syslog/syslog.go
@@ -63,7 +63,7 @@ func SampleData() TemplateData {
 	return TemplateData{
 		Facility: 20,
 		severity: 5,
-		dateTime: dateTime: time.Now().UTC(),
+		dateTime: time.Now(),
 		Host:     viper.GetString("message.host"),
 		AppName:  viper.GetString("message.appname"),
 		PID:      1143,


### PR DESCRIPTION
This patch changes loggenerator to generate up-to-date timestamps even if sample randomization is disabled.
